### PR TITLE
Remove renovate hourly limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "prHourlyLimit": 0
 }


### PR DESCRIPTION
If you are just interested in testing, you may want to remove Renovate's default "2 new PRs per hour" rate limiting. It's put in place so that CI systems don't get swamped by too many PRs at once, but maybe that's not a concern for here so you can remove it to make sure there's no delay.